### PR TITLE
Configure salt cloud for new version 2018.3.0, install shade dependency

### DIFF
--- a/build.py
+++ b/build.py
@@ -57,7 +57,6 @@ class InfrastructureManager(object):
         self.prepare()
         router = self.os_facade.find_or_create_router(self.params['router_name'])
         network = self.os_facade.find_or_create_network(self.params['network_name'])
-        self.params['fixed_network_id'] = network.id
         subnet = self.os_facade.find_or_create_subnet(self.params['subnet_name'], network=network)
         port = self.os_facade.find_or_create_port(network, subnet)
         self.os_facade.add_interface_to_router(router, subnet, port)

--- a/build_utils/fab_utils.py
+++ b/build_utils/fab_utils.py
@@ -33,6 +33,8 @@ def _bootstrap_salt_master():
         with cd('/tmp'):
             run('curl -L https://bootstrap.saltstack.com -o install_salt.sh')
             sudo('sh install_salt.sh -M -L')
+            sudo('apt-get  --yes --force-yes install python-pip')
+            sudo('pip install shade')  # Salt Cloud 2018.3.0 requires shade but does not install it
 
 
 def bootstrap_salt_master(salt_master_address):

--- a/build_utils/salt_utils.py
+++ b/build_utils/salt_utils.py
@@ -17,23 +17,20 @@ def generate_openstack_conf(params):
     :return: StringIO populated with the generated openstack configuration.
     """
     openstack_conf_data = dict(
-        openstack_config=dict(
-            identity_url='%s/auth/tokens' % params['OS_AUTH_URL'],
-            auth_version=int(params['OS_IDENTITY_API_VERSION']),
-            compute_name='nova',  # TODO - can this be different ?
-            compute_region=params['OS_REGION_NAME'],
-            service_type='compute',
-            tenant=params['OS_USERNAME'],  # TODO - can the tenant be different from the username ?
-            domain=params['OS_USER_DOMAIN_NAME'],  # TODO - should this be the user or project domain name ?
-            user=params['OS_USERNAME'],
-            password=params['OS_PASSWORD'],
+        openstack=dict(
             driver='openstack',
-            ssh_key_name=params['key_name'],  # TODO - populate this earlier - currently done in facade.set_key_pair
-            insecure=False,
-            ssh_key_file='/etc/salt/pki/master/master.pem',
+            region_name=params['OS_REGION_NAME'],
+            auth=dict(
+                username=params['OS_USERNAME'],
+                password=params['OS_PASSWORD'],
+                project_id=params['OS_PROJECT_ID'],
+                auth_url=params['OS_AUTH_URL'],
+                user_domain_name=params['OS_USER_DOMAIN_NAME'],
+                project_domain_name=params['OS_PROJECT_DOMAIN_NAME'],
+            ),
             networks=[
-                dict(fixed=[params['fixed_network_id']]),  # TODO - populate this when known
-                dict(floating=['public']),
+                dict(name='public', nat_source=True),
+                dict(name=params['network_name'], nat_destination=True),
             ]
         )
     )

--- a/build_utils/utils.py
+++ b/build_utils/utils.py
@@ -55,8 +55,10 @@ def populate_openstack_params_from_environ(params, env_dict):
                 'OS_IDENTITY_API_VERSION',
                 'OS_REGION_NAME',
                 'OS_USERNAME',
+                'OS_PROJECT_DOMAIN_NAME',
                 'OS_USER_DOMAIN_NAME',
                 'OS_PASSWORD',
+                'OS_PROJECT_ID',
             ]
         }
     )

--- a/tests/test_build_salt_utils.py
+++ b/tests/test_build_salt_utils.py
@@ -25,32 +25,30 @@ class TestGenerateOpenStackConf(unittest.TestCase):
                 OS_REGION_NAME='RegionX',
                 OS_USERNAME='flateric',
                 OS_USER_DOMAIN_NAME='badger',
+                OS_PROJECT_DOMAIN_NAME='fox',
                 OS_PASSWORD='hackme',
+                OS_PROJECT_ID='183f44dd82457385d4d4d8e702c45661',
                 key_name='badman 1337',
-                fixed_network_id='d34db33f-80zx-789c-a1a2-1d12345a123d',
+                network_name='network-blog-dev',
         )
 
         expected = yaml.load(
             """\
-openstack_config:
-  auth_version: %(OS_IDENTITY_API_VERSION)d
-  compute_name: nova
-  compute_region: %(OS_REGION_NAME)s
-  domain: %(OS_USER_DOMAIN_NAME)s
+openstack:
   driver: openstack
-  identity_url: %(OS_AUTH_URL)s/auth/tokens
-  insecure: false
+  region_name: %(OS_REGION_NAME)s
+  auth:
+    username: %(OS_USERNAME)s
+    password: %(OS_PASSWORD)s
+    project_id: %(OS_PROJECT_ID)s
+    auth_url: %(OS_AUTH_URL)s
+    user_domain_name: %(OS_USER_DOMAIN_NAME)s
+    project_domain_name: %(OS_PROJECT_DOMAIN_NAME)s
   networks:
-  - fixed:
-    - %(fixed_network_id)s
-  - floating:
-    - public
-  password: %(OS_PASSWORD)s
-  service_type: compute
-  ssh_key_file: /etc/salt/pki/master/master.pem
-  ssh_key_name: %(key_name)s
-  tenant: %(OS_USERNAME)s
-  user: %(OS_USERNAME)s
+  - name: public
+    nat_source: true
+  - name: %(network_name)s
+    nat_destination: true
 """ % params
         )
 


### PR DESCRIPTION
Openstack functionality in Salt Cloud 2018.3.0 has been completely re-written to use the shade library, rather than libcloud. This has resulted in a different format for the cloud provider file. Also, installing salt cloud via the salt bootstrap script doesn't install shade; you need to do that yourself.